### PR TITLE
various internal improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iset"
 version = "0.1.1"
 authors = ["Timofey Prodanov <timofey.prodanov@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "Map and set with interval keys (x..y)."
 repository = "https://github.com/tprodanov/iset"
 readme = "README.md"
@@ -26,5 +26,5 @@ rand = "0.8"
 serde_json = "1.0"
 
 [features]
-default = ["dot"]
+default = ["dot", "serde"]
 dot = []

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,15 +1,16 @@
 //! Module with various iterators over `IntervalMap` and `IntervalSet`.
 
 use alloc::vec::Vec;
-use core::ops::{Range, RangeBounds, Bound};
 use core::iter::FusedIterator;
 use core::mem;
+use core::ops::{Bound, Range, RangeBounds};
 
-use super::{IntervalMap, Node, IndexType, check_ordered, BitVec};
+use super::{check_ordered, BitVec, IndexType, IntervalMap, Node};
 
 fn should_go_left<T, V, Ix>(nodes: &[Node<T, V, Ix>], index: Ix, start_bound: Bound<&T>) -> bool
-where T: PartialOrd + Copy,
-      Ix: IndexType,
+where
+    T: PartialOrd + Copy,
+    Ix: IndexType,
 {
     if !nodes[index.get()].left.defined() {
         return false;
@@ -22,8 +23,9 @@ where T: PartialOrd + Copy,
 }
 
 fn should_go_right<T, V, Ix>(nodes: &[Node<T, V, Ix>], index: Ix, end_bound: Bound<&T>) -> bool
-where T: PartialOrd + Copy,
-      Ix: IndexType,
+where
+    T: PartialOrd + Copy,
+    Ix: IndexType,
 {
     if !nodes[index.get()].right.defined() {
         return false;
@@ -45,7 +47,7 @@ impl ActionStack {
     }
 
     #[inline]
-    fn push(& mut self) {
+    fn push(&mut self) {
         self.0.push(false);
         self.0.push(false);
     }
@@ -94,10 +96,16 @@ impl ActionStack {
     }
 }
 
-fn move_to_next<T, V, R, Ix>(nodes: &[Node<T, V, Ix>], mut index: Ix, range: &R, stack: &mut ActionStack) -> Ix
-where T: PartialOrd + Copy,
-      R: RangeBounds<T>,
-      Ix: IndexType,
+fn move_to_next<T, V, R, Ix>(
+    nodes: &[Node<T, V, Ix>],
+    mut index: Ix,
+    range: &R,
+    stack: &mut ActionStack,
+) -> Ix
+where
+    T: PartialOrd + Copy,
+    R: RangeBounds<T>,
+    Ix: IndexType,
 {
     while index.defined() {
         if stack.can_go_left() {

--- a/src/set.rs
+++ b/src/set.rs
@@ -195,7 +195,7 @@ impl<T: PartialOrd + Copy, Ix: IndexType> IntervalSet<T, Ix> {
     /// Output is sorted by intervals.
     ///
     /// Panics if `interval` is empty or contains a value that cannot be compared (such as `NAN`).
-    pub fn iter<'a, R>(&'a self, query: R) -> Intervals<'a, T, (), R, Ix>
+    pub fn iter<R>(&self, query: R) -> Intervals<'_, T, (), R, Ix>
     where
         R: RangeBounds<T>,
     {
@@ -204,7 +204,7 @@ impl<T: PartialOrd + Copy, Ix: IndexType> IntervalSet<T, Ix> {
 
     /// Iterates over intervals `x..y` that overlap the `point`. Same as `iter(point..=point)`.
     /// See [iter](#method.iter) for more details.
-    pub fn overlap<'a>(&'a self, point: T) -> Intervals<'a, T, (), RangeInclusive<T>, Ix> {
+    pub fn overlap(&self, point: T) -> Intervals<'_, T, (), RangeInclusive<T>, Ix> {
         self.inner.intervals(point..=point)
     }
 
@@ -219,7 +219,7 @@ impl<T: PartialOrd + Copy, Ix: IndexType> IntervalSet<T, Ix> {
 
     /// Creates an unsorted iterator over all intervals `x..y`.
     /// Slightly faster than the sorted iterator, although both take *O(N)*.
-    pub fn unsorted_iter<'a>(&'a self) -> UnsIntervals<'a, T, (), Ix> {
+    pub fn unsorted_iter(&self) -> UnsIntervals<'_, T, (), Ix> {
         UnsIntervals::new(&self.inner)
     }
 
@@ -285,7 +285,7 @@ impl<T: PartialOrd + Copy + Debug, Ix: IndexType> Debug for IntervalSet<T, Ix> {
             } else {
                 need_comma = true;
             }
-            write!(f, "{:?}", interval)?;
+            write!(f, "{interval:?}")?;
         }
         write!(f, "}}")
     }

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,18 +1,18 @@
 //! `IntervalSet` implementation.
 
-use core::ops::{Range, RangeInclusive, RangeBounds, RangeFull, AddAssign, Sub};
-use core::fmt::{self, Debug, Formatter};
-use core::iter::{FromIterator, IntoIterator};
 #[cfg(feature = "dot")]
 use core::fmt::Display;
+use core::fmt::{self, Debug, Formatter};
+use core::iter::{FromIterator, IntoIterator};
+use core::ops::{AddAssign, Range, RangeBounds, RangeFull, RangeInclusive, Sub};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "dot")]
 use std::io::{self, Write};
-#[cfg(feature = "serde")]
-use serde::{Serialize, Serializer, Deserialize, Deserializer};
 
-use super::IntervalMap;
-use super::ix::{IndexType, DefaultIx};
 use super::iter::*;
+use super::ix::{DefaultIx, IndexType};
+use super::IntervalMap;
 
 /// Set with interval keys (ranges `x..y`). Newtype over `IntervalMap<T, ()>`.
 /// See [IntervalMap](../struct.IntervalMap.html) for more information.
@@ -59,8 +59,9 @@ use super::iter::*;
 /// [force_insert](../struct.IntervalMap.html#method.force_insert), and completely forbids duplicate intervals.
 #[derive(Clone)]
 pub struct IntervalSet<T, Ix = DefaultIx>
-where T: PartialOrd + Copy,
-      Ix: IndexType,
+where
+    T: PartialOrd + Copy,
+    Ix: IndexType,
 {
     inner: IntervalMap<T, (), Ix>,
 }
@@ -93,7 +94,8 @@ impl<T: PartialOrd + Copy, Ix: IndexType> IntervalSet<T, Ix> {
     ///
     /// Panics if the intervals are not sorted or if there are equal intervals.
     pub fn from_sorted<I>(iter: I) -> Self
-    where I: Iterator<Item = Range<T>>,
+    where
+        I: Iterator<Item = Range<T>>,
     {
         Self {
             inner: IntervalMap::from_sorted(iter.map(|range| (range, ()))),
@@ -182,7 +184,9 @@ impl<T: PartialOrd + Copy, Ix: IndexType> IntervalSet<T, Ix> {
     /// Equivalent to `set.iter(query).next().is_some()`, but much faster.
     #[inline]
     pub fn has_overlap<R>(&self, query: R) -> bool
-    where R: RangeBounds<T>, {
+    where
+        R: RangeBounds<T>,
+    {
         self.inner.has_overlap(query)
     }
 
@@ -192,7 +196,8 @@ impl<T: PartialOrd + Copy, Ix: IndexType> IntervalSet<T, Ix> {
     ///
     /// Panics if `interval` is empty or contains a value that cannot be compared (such as `NAN`).
     pub fn iter<'a, R>(&'a self, query: R) -> Intervals<'a, T, (), R, Ix>
-    where R: RangeBounds<T>,
+    where
+        R: RangeBounds<T>,
     {
         self.inner.intervals(query)
     }
@@ -206,7 +211,8 @@ impl<T: PartialOrd + Copy, Ix: IndexType> IntervalSet<T, Ix> {
     /// Consumes [IntervalSet](struct.IntervalSet.html) and iterates over intervals `x..y` that overlap the `query`.
     /// See [iter](#method.iter) for more details.
     pub fn into_iter<R>(self, query: R) -> IntoIntervals<T, (), R, Ix>
-    where R: RangeBounds<T>,
+    where
+        R: RangeBounds<T>,
     {
         IntoIntervals::new(self.inner, query)
     }
@@ -244,8 +250,9 @@ impl<T: PartialOrd + Copy> FromIterator<Range<T>> for IntervalSet<T> {
 }
 
 impl<T, Ix> IntervalSet<T, Ix>
-where T: PartialOrd + Copy + Default + AddAssign + Sub<Output = T>,
-      Ix: IndexType,
+where
+    T: PartialOrd + Copy + Default + AddAssign + Sub<Output = T>,
+    Ix: IndexType,
 {
     /// Calculates the total length of the `query` that is covered by intervals in the map.
     /// Takes *O(log N + K)* where *K* is the number of intervals that overlap `query`.
@@ -253,7 +260,8 @@ where T: PartialOrd + Copy + Default + AddAssign + Sub<Output = T>,
     /// See [IntervalMap::covered_len](../struct.IntervalMap.html#method.covered_len) for more details.
     #[inline]
     pub fn covered_len<R>(&self, query: R) -> T
-    where R: RangeBounds<T>
+    where
+        R: RangeBounds<T>,
     {
         self.inner.covered_len(query)
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,22 +2,31 @@ extern crate rand;
 #[cfg(feature = "serde")]
 extern crate serde_json;
 
-use std::string::String;
-use std::ops::{self, Range, RangeBounds, Bound};
+use rand::prelude::*;
 use std::fmt::{Debug, Write};
 use std::fs::File;
+use std::ops::{self, Bound, Range, RangeBounds};
 use std::path::Path;
-use rand::prelude::*;
+use std::string::String;
 
 use super::*;
 
 /// Returns distance to leaves (only black nodes).
-fn validate_tree_recursive<T, V, Ix>(tree: &IntervalMap<T, V, Ix>, index: Ix, upper_interval: &mut Interval<T>,
-    visited: &mut BitVec) -> u32
-where T: PartialOrd + Copy,
-      Ix: IndexType,
+fn validate_tree_recursive<T, V, Ix>(
+    tree: &IntervalMap<T, V, Ix>,
+    index: Ix,
+    upper_interval: &mut Interval<T>,
+    visited: &mut BitVec,
+) -> u32
+where
+    T: PartialOrd + Copy,
+    Ix: IndexType,
 {
-    assert!(!visited.get(index.get()), "The tree contains a cycle: node {} was visited twice", index);
+    assert!(
+        !visited.get(index.get()),
+        "The tree contains a cycle: node {} was visited twice",
+        index
+    );
     visited.set(index.get(), true);
 
     let node = &tree.nodes[index.get()];
@@ -27,26 +36,56 @@ where T: PartialOrd + Copy,
 
     let left_depth = if left.defined() {
         if tree.is_red(index) {
-            assert!(tree.is_black(left), "Red node {} has a red child {}", index, left);
+            assert!(
+                tree.is_black(left),
+                "Red node {} has a red child {}",
+                index,
+                left
+            );
         }
-        Some(validate_tree_recursive(tree, left, &mut down_interval, visited))
+        Some(validate_tree_recursive(
+            tree,
+            left,
+            &mut down_interval,
+            visited,
+        ))
     } else {
         None
     };
     let right_depth = if right.defined() {
         if tree.is_red(index) {
-            assert!(tree.is_black(right), "Red node {} has a red child {}", index, right);
+            assert!(
+                tree.is_black(right),
+                "Red node {} has a red child {}",
+                index,
+                right
+            );
         }
-        Some(validate_tree_recursive(tree, right, &mut down_interval, visited))
+        Some(validate_tree_recursive(
+            tree,
+            right,
+            &mut down_interval,
+            visited,
+        ))
     } else {
         None
     };
-    assert!(down_interval == node.subtree_interval, "Interval != subtree interval for node {}", index);
+    assert!(
+        down_interval == node.subtree_interval,
+        "Interval != subtree interval for node {}",
+        index
+    );
     upper_interval.extend(&down_interval);
 
     match (left_depth, right_depth) {
-        (Some(x), Some(y)) => assert!(x == y, "Node {} has different depths to leaves: {} != {}", index, x, y),
-        _ => {},
+        (Some(x), Some(y)) => assert!(
+            x == y,
+            "Node {} has different depths to leaves: {} != {}",
+            index,
+            x,
+            y
+        ),
+        _ => {}
     }
     let depth = left_depth.or(right_depth).unwrap_or(0);
     if tree.is_black(index) {
@@ -59,7 +98,11 @@ where T: PartialOrd + Copy,
 fn validate<T: PartialOrd + Copy, V, Ix: IndexType>(tree: &IntervalMap<T, V, Ix>, size: usize) {
     assert_eq!(size, tree.len(), "Tree sizes do not match");
     assert_eq!(size > 0, tree.root.defined(), "Tree root != size");
-    assert_eq!(tree.len(), tree.colors.len(), "Number of nodes != number of colors");
+    assert_eq!(
+        tree.len(),
+        tree.colors.len(),
+        "Number of nodes != number of colors"
+    );
 
     if !tree.root.defined() {
         assert!(tree.nodes.is_empty(), "Non empty nodes with an empty root");
@@ -67,9 +110,19 @@ fn validate<T: PartialOrd + Copy, V, Ix: IndexType>(tree: &IntervalMap<T, V, Ix>
     }
     for i in 0..tree.nodes.len() {
         if i == tree.root.get() {
-            assert!(!tree.nodes[i].parent.defined(), "Root {} has a parent {}", i, tree.nodes[i].parent);
+            assert!(
+                !tree.nodes[i].parent.defined(),
+                "Root {} has a parent {}",
+                i,
+                tree.nodes[i].parent
+            );
         } else {
-            assert!(tree.nodes[i].parent.defined(), "Non-root {} has an empty parent (root is {})", i, tree.root);
+            assert!(
+                tree.nodes[i].parent.defined(),
+                "Non-root {} has an empty parent (root is {})",
+                i,
+                tree.root
+            );
         }
     }
 
@@ -77,10 +130,18 @@ fn validate<T: PartialOrd + Copy, V, Ix: IndexType>(tree: &IntervalMap<T, V, Ix>
     let mut interval = node.interval.clone();
     let mut visited = BitVec::from_elem(tree.nodes.len(), false);
     validate_tree_recursive(tree, tree.root, &mut interval, &mut visited);
-    assert!(interval == node.subtree_interval, "Interval != subtree interval for node {}", tree.root);
+    assert!(
+        interval == node.subtree_interval,
+        "Interval != subtree interval for node {}",
+        tree.root
+    );
 
     for i in 0..tree.len() {
-        assert!(visited.get(i), "The tree is disjoint: node {} has no connection to the root", i);
+        assert!(
+            visited.get(i),
+            "The tree is disjoint: node {} has no connection to the root",
+            i
+        );
     }
 }
 
@@ -89,9 +150,7 @@ fn intersects<T: PartialOrd, R: RangeBounds<T>>(range: &Range<T>, query: &R) -> 
         Bound::Included(value) => value >= &range.start,
         Bound::Excluded(value) => value > &range.start,
         Bound::Unbounded => true,
-    })
-        &&
-    (match query.start_bound() {
+    }) && (match query.start_bound() {
         Bound::Included(value) | Bound::Excluded(value) => value < &range.end,
         Bound::Unbounded => true,
     })
@@ -107,9 +166,7 @@ struct NaiveIntervalMap<T: PartialOrd + Copy, V> {
 
 impl<T: PartialOrd + Copy, V> NaiveIntervalMap<T, V> {
     fn new() -> Self {
-        Self {
-            nodes: Vec::new(),
-        }
+        Self { nodes: Vec::new() }
     }
 
     fn len(&self) -> usize {
@@ -120,13 +177,21 @@ impl<T: PartialOrd + Copy, V> NaiveIntervalMap<T, V> {
         self.nodes.push((range, value));
     }
 
-    fn iter<'a, R: 'a + RangeBounds<T>>(&'a self, query: R) -> impl Iterator<Item = (Range<T>, &V)> + 'a {
-        self.nodes.iter().filter(move |(range, _value)| intersects(range, &query))
+    fn iter<'a, R: 'a + RangeBounds<T>>(
+        &'a self,
+        query: R,
+    ) -> impl Iterator<Item = (Range<T>, &V)> + 'a {
+        self.nodes
+            .iter()
+            .filter(move |(range, _value)| intersects(range, &query))
             .map(|(range, value)| (range.clone(), value))
     }
 
     fn all_matching<'a>(&'a self, query: Range<T>) -> impl Iterator<Item = &V> + 'a {
-        self.nodes.iter().filter(move |(range, _value)| range_eq(&range, &query)).map(|(_range, value)| value)
+        self.nodes
+            .iter()
+            .filter(move |(range, _value)| range_eq(&range, &query))
+            .map(|(_range, value)| value)
     }
 
     fn remove_random(&mut self, rng: &mut impl Rng) -> (Range<T>, V) {
@@ -175,7 +240,10 @@ impl<V> NaiveIntervalMap<i32, V> {
     }
 }
 
-fn generate_ordered_pair<T: PartialOrd + Copy, F: FnMut() -> T>(generator: &mut F, forbid_eq: bool) -> (T, T) {
+fn generate_ordered_pair<T: PartialOrd + Copy, F: FnMut() -> T>(
+    generator: &mut F,
+    forbid_eq: bool,
+) -> (T, T) {
     let a = generator();
     let mut b = generator();
     while forbid_eq && a == b {
@@ -188,10 +256,15 @@ fn generate_ordered_pair<T: PartialOrd + Copy, F: FnMut() -> T>(generator: &mut 
     }
 }
 
-fn modify_maps<T, F>(naive: &mut NaiveIntervalMap<T, u32>, tree: &mut IntervalMap<T, u32>, n_inserts: u32,
-        mut generator: F) -> String
-where T: PartialOrd + Copy + Debug,
-      F: FnMut() -> Range<T>,
+fn modify_maps<T, F>(
+    naive: &mut NaiveIntervalMap<T, u32>,
+    tree: &mut IntervalMap<T, u32>,
+    n_inserts: u32,
+    mut generator: F,
+) -> String
+where
+    T: PartialOrd + Copy + Debug,
+    F: FnMut() -> Range<T>,
 {
     let mut history = String::new();
     for i in 0..n_inserts {
@@ -199,7 +272,11 @@ where T: PartialOrd + Copy + Debug,
         writeln!(history, "insert({:?})", range).unwrap();
         naive.insert(range.clone(), i);
         if let Some(value) = tree.insert(range.clone(), i) {
-            let i = naive.nodes.iter().position(|(range2, _value2)| range == *range2).unwrap();
+            let i = naive
+                .nodes
+                .iter()
+                .position(|(range2, _value2)| range == *range2)
+                .unwrap();
             assert_eq!(naive.nodes[i].1, value);
             naive.nodes.swap_remove(i);
         }
@@ -208,11 +285,16 @@ where T: PartialOrd + Copy + Debug,
 }
 
 fn save_iter<'a, T, I>(iter: I) -> Vec<(Range<T>, u32)>
-where T: PartialOrd + Copy,
-      I: Iterator<Item = (Range<T>, &'a u32)>,
+where
+    T: PartialOrd + Copy,
+    I: Iterator<Item = (Range<T>, &'a u32)>,
 {
     let mut res: Vec<_> = iter.map(|(range, value)| (range, *value)).collect();
-    res.sort_by(|a, b| (a.0.start, a.0.end, a.1).partial_cmp(&(b.0.start, b.0.end, b.1)).unwrap());
+    res.sort_by(|a, b| {
+        (a.0.start, a.0.end, a.1)
+            .partial_cmp(&(b.0.start, b.0.end, b.1))
+            .unwrap()
+    });
     res
 }
 
@@ -232,16 +314,18 @@ fn generate_float_rounding() -> impl (FnMut() -> f64) {
     move || (rng.gen::<f64>() * MULT).round() / MULT
 }
 
-fn generate_range<T: PartialOrd + Copy + Debug, F: FnMut() -> T>(mut generator: F)
-        -> impl (FnMut() -> Range<T>) {
+fn generate_range<T: PartialOrd + Copy + Debug, F: FnMut() -> T>(
+    mut generator: F,
+) -> impl (FnMut() -> Range<T>) {
     move || {
         let (a, b) = generate_ordered_pair(&mut generator, true);
         a..b
     }
 }
 
-fn generate_range_from<T: PartialOrd + Copy + Debug, F: FnMut() -> T>(mut generator: F)
-        -> impl (FnMut() -> ops::RangeFrom<T>) {
+fn generate_range_from<T: PartialOrd + Copy + Debug, F: FnMut() -> T>(
+    mut generator: F,
+) -> impl (FnMut() -> ops::RangeFrom<T>) {
     move || generator()..
 }
 
@@ -249,29 +333,37 @@ fn generate_range_full() -> ops::RangeFull {
     ..
 }
 
-fn generate_range_incl<T: PartialOrd + Copy + Debug, F: FnMut() -> T>(mut generator: F)
-        -> impl (FnMut() -> ops::RangeInclusive<T>) {
+fn generate_range_incl<T: PartialOrd + Copy + Debug, F: FnMut() -> T>(
+    mut generator: F,
+) -> impl (FnMut() -> ops::RangeInclusive<T>) {
     move || {
         let (a, b) = generate_ordered_pair(&mut generator, false);
         a..=b
     }
 }
 
-fn generate_range_to<T: PartialOrd + Copy + Debug, F: FnMut() -> T>(mut generator: F)
-        -> impl (FnMut() -> ops::RangeTo<T>) {
+fn generate_range_to<T: PartialOrd + Copy + Debug, F: FnMut() -> T>(
+    mut generator: F,
+) -> impl (FnMut() -> ops::RangeTo<T>) {
     move || ..generator()
 }
 
-fn generate_range_to_incl<T: PartialOrd + Copy + Debug, F: FnMut() -> T>(mut generator: F)
-        -> impl (FnMut() -> ops::RangeToInclusive<T>) {
+fn generate_range_to_incl<T: PartialOrd + Copy + Debug, F: FnMut() -> T>(
+    mut generator: F,
+) -> impl (FnMut() -> ops::RangeToInclusive<T>) {
     move || ..=generator()
 }
 
-fn search_rand<T, R, F>(naive: &mut NaiveIntervalMap<T, u32>, tree: &mut IntervalMap<T, u32>, n_searches: u32,
-        mut range_generator: F, history: &str)
-where T: PartialOrd + Copy + Debug,
-      R: RangeBounds<T> + Debug + Clone,
-      F: FnMut() -> R,
+fn search_rand<T, R, F>(
+    naive: &mut NaiveIntervalMap<T, u32>,
+    tree: &mut IntervalMap<T, u32>,
+    n_searches: u32,
+    mut range_generator: F,
+    history: &str,
+) where
+    T: PartialOrd + Copy + Debug,
+    R: RangeBounds<T> + Debug + Clone,
+    F: FnMut() -> R,
 {
     for _ in 0..n_searches {
         let range = range_generator();
@@ -293,10 +385,17 @@ where T: PartialOrd + Copy + Debug,
 }
 
 fn compare_extremums<T>(naive: &NaiveIntervalMap<T, u32>, tree: &IntervalMap<T, u32>, history: &str)
-where T: PartialOrd + Copy + Debug
+where
+    T: PartialOrd + Copy + Debug,
 {
-    let smallest_a = naive.nodes.iter()
-        .min_by(|a, b| (a.0.start, a.0.end, a.1).partial_cmp(&(b.0.start, b.0.end, b.1)).unwrap())
+    let smallest_a = naive
+        .nodes
+        .iter()
+        .min_by(|a, b| {
+            (a.0.start, a.0.end, a.1)
+                .partial_cmp(&(b.0.start, b.0.end, b.1))
+                .unwrap()
+        })
         .map(|(interval, _)| interval.clone());
     let smallest_b = tree.smallest().map(|(interval, _)| interval);
     if smallest_a != smallest_b {
@@ -305,8 +404,14 @@ where T: PartialOrd + Copy + Debug
         assert_eq!(smallest_a, smallest_b);
     }
 
-    let largest_a = naive.nodes.iter()
-        .max_by(|a, b| (a.0.start, a.0.end, a.1).partial_cmp(&(b.0.start, b.0.end, b.1)).unwrap())
+    let largest_a = naive
+        .nodes
+        .iter()
+        .max_by(|a, b| {
+            (a.0.start, a.0.end, a.1)
+                .partial_cmp(&(b.0.start, b.0.end, b.1))
+                .unwrap()
+        })
         .map(|(interval, _)| interval.clone());
     let largest_b = tree.largest().map(|(interval, _)| interval);
     if largest_a != largest_b {
@@ -316,8 +421,13 @@ where T: PartialOrd + Copy + Debug
     }
 }
 
-fn compare_match_results<T>(naive: &NaiveIntervalMap<T, u32>, tree: &IntervalMap<T, u32>, history: &str, range: Range<T>)
-where T: PartialOrd + Copy + Clone + Debug
+fn compare_match_results<T>(
+    naive: &NaiveIntervalMap<T, u32>,
+    tree: &IntervalMap<T, u32>,
+    history: &str,
+    range: Range<T>,
+) where
+    T: PartialOrd + Copy + Clone + Debug,
 {
     let values: Vec<u32> = naive.all_matching(range.clone()).map(|v| *v).collect();
     let mut correct = true;
@@ -327,17 +437,26 @@ where T: PartialOrd + Copy + Clone + Debug
         None => values.is_empty(),
     };
     if !correct {
-        println!("Range: {:?},   values: {:?},   tree.get: {:?}", range, values, tree.get(range.clone()));
+        println!(
+            "Range: {:?},   values: {:?},   tree.get: {:?}",
+            range,
+            values,
+            tree.get(range.clone())
+        );
         println!("{}", history);
         println!();
         panic!();
     }
 }
 
-fn compare_exact_matching<T, F>(naive: &NaiveIntervalMap<T, u32>, tree: &IntervalMap<T, u32>, history: &str,
-    mut generator: F)
-where T: PartialOrd + Copy + Debug,
-      F: FnMut() -> Range<T>,
+fn compare_exact_matching<T, F>(
+    naive: &NaiveIntervalMap<T, u32>,
+    tree: &IntervalMap<T, u32>,
+    history: &str,
+    mut generator: F,
+) where
+    T: PartialOrd + Copy + Debug,
+    F: FnMut() -> Range<T>,
 {
     for (range, _value) in &naive.nodes {
         compare_match_results(naive, tree, history, range.clone());
@@ -348,10 +467,15 @@ where T: PartialOrd + Copy + Debug,
     }
 }
 
-fn check_covered_len<V, R, F>(naive: &NaiveIntervalMap<i32, V>, tree: &IntervalMap<i32, V>,
-    count: u32, mut generator: F, history: &str)
-where R: RangeBounds<i32> + Clone + Debug,
-      F: FnMut() -> R,
+fn check_covered_len<V, R, F>(
+    naive: &NaiveIntervalMap<i32, V>,
+    tree: &IntervalMap<i32, V>,
+    count: u32,
+    mut generator: F,
+    history: &str,
+) where
+    R: RangeBounds<i32> + Clone + Debug,
+    F: FnMut() -> R,
 {
     for _ in 0..count {
         let query = generator();
@@ -360,7 +484,10 @@ where R: RangeBounds<i32> + Clone + Debug,
         if len1 != len2 {
             println!("{}", history);
             println!();
-            println!("Query = {:?},   naive len = {},   map len = {}", query, len1, len2);
+            println!(
+                "Query = {:?},   naive len = {},   map len = {}",
+                query, len1, len2
+            );
             panic!();
         }
         assert_eq!(len1, len2);
@@ -377,11 +504,13 @@ where
     loop {
         match (iter1.next(), iter2.next()) {
             (None, None) => break,
-            (x, y) => if x != y {
-                println!("{}", history);
-                println!();
-                assert_eq!(x, y);
-            },
+            (x, y) => {
+                if x != y {
+                    println!("{}", history);
+                    println!();
+                    assert_eq!(x, y);
+                }
+            }
         }
     }
 }
@@ -391,7 +520,12 @@ fn test_int_inserts() {
     const COUNT: u32 = 1000;
     let mut naive = NaiveIntervalMap::new();
     let mut tree = IntervalMap::new();
-    let history = modify_maps(&mut naive, &mut tree, COUNT, generate_range(generate_int(20, 120)));
+    let history = modify_maps(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range(generate_int(20, 120)),
+    );
 
     let output_path = Path::new("tests/data/int.dot");
     let folders = output_path.parent().unwrap();
@@ -403,12 +537,42 @@ fn test_int_inserts() {
 
     let mut generator = generate_int(0, 140);
     compare_exact_matching(&naive, &tree, &history, generate_range(&mut generator));
-    search_rand(&mut naive, &mut tree, COUNT, generate_range(&mut generator), &history);
-    search_rand(&mut naive, &mut tree, COUNT, generate_range_from(&mut generator), &history);
+    search_rand(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range(&mut generator),
+        &history,
+    );
+    search_rand(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range_from(&mut generator),
+        &history,
+    );
     search_rand(&mut naive, &mut tree, 1, generate_range_full, &history);
-    search_rand(&mut naive, &mut tree, COUNT, generate_range_incl(&mut generator), &history);
-    search_rand(&mut naive, &mut tree, COUNT, generate_range_to(&mut generator), &history);
-    search_rand(&mut naive, &mut tree, COUNT, generate_range_to_incl(&mut generator), &history);
+    search_rand(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range_incl(&mut generator),
+        &history,
+    );
+    search_rand(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range_to(&mut generator),
+        &history,
+    );
+    search_rand(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range_to_incl(&mut generator),
+        &history,
+    );
 }
 
 #[test]
@@ -416,16 +580,51 @@ fn test_covered_len() {
     const COUNT: u32 = 1000;
     let mut naive = NaiveIntervalMap::new();
     let mut tree = IntervalMap::new();
-    let history = modify_maps(&mut naive, &mut tree, COUNT, generate_range(generate_int(-500, 500)));
+    let history = modify_maps(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range(generate_int(-500, 500)),
+    );
     validate(&tree, naive.len());
 
     let mut generator = generate_int(-510, 510);
-    check_covered_len(&mut naive, &mut tree, COUNT, generate_range(&mut generator), &history);
-    check_covered_len(&mut naive, &mut tree, COUNT, generate_range_from(&mut generator), &history);
+    check_covered_len(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range(&mut generator),
+        &history,
+    );
+    check_covered_len(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range_from(&mut generator),
+        &history,
+    );
     check_covered_len(&mut naive, &mut tree, 1, generate_range_full, &history);
-    check_covered_len(&mut naive, &mut tree, COUNT, generate_range_incl(&mut generator), &history);
-    check_covered_len(&mut naive, &mut tree, COUNT, generate_range_to(&mut generator), &history);
-    check_covered_len(&mut naive, &mut tree, COUNT, generate_range_to_incl(&mut generator), &history);
+    check_covered_len(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range_incl(&mut generator),
+        &history,
+    );
+    check_covered_len(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range_to(&mut generator),
+        &history,
+    );
+    check_covered_len(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range_to_incl(&mut generator),
+        &history,
+    );
 }
 
 #[test]
@@ -433,7 +632,12 @@ fn test_float_inserts() {
     const COUNT: u32 = 1000;
     let mut naive = NaiveIntervalMap::new();
     let mut tree = IntervalMap::new();
-    let history = modify_maps(&mut naive, &mut tree, COUNT, generate_range(generate_float(0.0, 1000.0)));
+    let history = modify_maps(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range(generate_float(0.0, 1000.0)),
+    );
 
     let output_path = Path::new("tests/data/float.dot");
     let folders = output_path.parent().unwrap();
@@ -444,12 +648,42 @@ fn test_float_inserts() {
     compare_extremums(&naive, &tree, &history);
 
     let mut generator = generate_float(-50.0, 1050.0);
-    search_rand(&mut naive, &mut tree, COUNT, generate_range(&mut generator), &history);
-    search_rand(&mut naive, &mut tree, COUNT, generate_range_from(&mut generator), &history);
+    search_rand(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range(&mut generator),
+        &history,
+    );
+    search_rand(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range_from(&mut generator),
+        &history,
+    );
     search_rand(&mut naive, &mut tree, 1, generate_range_full, &history);
-    search_rand(&mut naive, &mut tree, COUNT, generate_range_incl(&mut generator), &history);
-    search_rand(&mut naive, &mut tree, COUNT, generate_range_to(&mut generator), &history);
-    search_rand(&mut naive, &mut tree, COUNT, generate_range_to_incl(&mut generator), &history);
+    search_rand(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range_incl(&mut generator),
+        &history,
+    );
+    search_rand(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range_to(&mut generator),
+        &history,
+    );
+    search_rand(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range_to_incl(&mut generator),
+        &history,
+    );
 }
 
 #[test]
@@ -460,7 +694,7 @@ fn test_from_sorted() {
     validate(&map, 0);
 
     for i in 0..COUNT {
-        vec.push((i..i+1, i));
+        vec.push((i..i + 1, i));
         map = IntervalMap::from_sorted(vec.clone().into_iter());
         assert_eq!(map.len(), vec.len());
         validate(&map, vec.len());
@@ -477,7 +711,12 @@ fn test_serde() {
     const COUNT: u32 = 1000;
     let mut naive = NaiveIntervalMap::new();
     let mut tree: IntervalMap<i32, u32> = IntervalMap::new();
-    let history = modify_maps(&mut naive, &mut tree, COUNT, generate_range(generate_int(0, 10000)));
+    let history = modify_maps(
+        &mut naive,
+        &mut tree,
+        COUNT,
+        generate_range(generate_int(0, 10000)),
+    );
 
     let json_path = Path::new("tests/data/serde.json");
     let folders = json_path.parent().unwrap();

--- a/src/tree_rm.rs
+++ b/src/tree_rm.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 
 impl<T: PartialOrd + Copy, V, Ix: IndexType> IntervalMap<T, V, Ix> {
@@ -103,10 +102,18 @@ impl<T: PartialOrd + Copy, V, Ix: IndexType> IntervalMap<T, V, Ix> {
             let parent = &self.nodes[parent_ix.get()];
             let parent_black = self.is_black(parent_ix);
             let node_is_left = parent.left == ix;
-            let sibling_ix = if node_is_left { parent.right } else { parent.left };
+            let sibling_ix = if node_is_left {
+                parent.right
+            } else {
+                parent.left
+            };
             let (close_nephew_ix, distant_nephew_ix) = if sibling_ix.defined() {
                 let sibling = &self.nodes[sibling_ix.get()];
-                if node_is_left { (sibling.left, sibling.right) } else { (sibling.right, sibling.left) }
+                if node_is_left {
+                    (sibling.left, sibling.right)
+                } else {
+                    (sibling.right, sibling.left)
+                }
             } else {
                 (Ix::MAX, Ix::MAX)
             };
@@ -155,7 +162,8 @@ impl<T: PartialOrd + Copy, V, Ix: IndexType> IntervalMap<T, V, Ix> {
             else {
                 debug_assert!(sibling_black && !distant_nephew_black);
                 // parent's color -> sibling's color.
-                self.colors.set(sibling_ix.get(), self.colors.get(parent_ix.get()));
+                self.colors
+                    .set(sibling_ix.get(), self.colors.get(parent_ix.get()));
                 self.set_black(parent_ix);
                 self.set_black(distant_nephew_ix);
                 self.replace_children(parent_ix, sibling_ix);
@@ -200,7 +208,9 @@ impl<T: PartialOrd + Copy, V, Ix: IndexType> IntervalMap<T, V, Ix> {
             }
         };
         if rm_ix != ix {
-            unsafe { self.swap_nodes(ix, rm_ix); }
+            unsafe {
+                self.swap_nodes(ix, rm_ix);
+            }
         }
 
         let rm_node = &self.nodes[rm_ix.get()];
@@ -209,7 +219,9 @@ impl<T: PartialOrd + Copy, V, Ix: IndexType> IntervalMap<T, V, Ix> {
 
         if child_ix.defined() {
             // Removed node has a child, replace the node with the child and remove the child.
-            unsafe { self.swap_nodes(rm_ix, child_ix); }
+            unsafe {
+                self.swap_nodes(rm_ix, child_ix);
+            }
             self.remove_child(rm_ix, child_ix);
             self.fix_intervals_up(rm_ix);
             Some(self.swap_remove(child_ix))


### PR DESCRIPTION
Hi @tprodanov thanks for adding `remove_where` and other changes!  While I was working on `remove_select`, I noticed some things I thought could be improved in the codebase and wanted to see how they would pan out so I went ahead and implemented them.  This PR is against the older version of the code.  If you are interested in taking any/all of these changes, I'd be happy to rebase or break out any subset of the changes.  Here are the major changes:

* Distinguish between definitely-valid and potentially-invalid index values by using `Option<Ix>` vs `Ix`.  In order to not increase memory footprint, `Ix` is changed to `NonZeroU*`.  (`Option<NonZeroU32>` is 4 bytes, same as `u32`.)  I think this is a great improvement to being able to understand the code, catch more programming errors at compile time, and it lead to many opportunities to clarify surrounding code (e.g. with `match` or `map`).  However, I haven't been able to figure out how to preserve the existing API where you can create a `RangeMap<X, Y, u64>`; consumers would have to be updated to use `RangeMap<X, Y, NonZeroU64>`.  Not sure how impactful this would be for consumers.
* Add accessors for `IntervalMap::nodes[]`.  Slightly reduces the amount of repeated code, and makes it more clear where nodes are being mutated.
* Minimize unsafe code in `swap_nodes()`.
* Reformat code with `rustfmt`.
* Resolve clippy nits.

Here is an example where the change is pretty mechanical, with no additional cleanup possible.  But you can't forget the `.defined()` check and then panic at runtime :)
old:
```rust
   fn update_subtree_interval(&mut self, index: Ix) {
        let node = &self.nodes[index.get()];
        let mut subtree_interval = node.interval.clone();
        if node.left.defined() {
            subtree_interval.extend(&self.nodes[node.left.get()].subtree_interval);
        }
        if node.right.defined() {
            subtree_interval.extend(&self.nodes[node.right.get()].subtree_interval);
        }
        self.nodes[index.get()].subtree_interval = subtree_interval;
    }
```
new:
```rust
    fn update_subtree_interval(&mut self, index: Ix) {
        let node = self.node(index);
        let mut subtree_interval = node.interval.clone();
        if let Some(left) = node.left {
            subtree_interval.extend(&self.node(left).subtree_interval);
        }
        if let Some(right) = node.right {
            subtree_interval.extend(&self.node(right).subtree_interval);
        }
        self.node_mut(index).subtree_interval = subtree_interval;
    }
```
You can see the substantial changes more clearly by looking at just the [last commit](https://github.com/tprodanov/iset/commit/f309d023cfb9bc4ea0ecefc48111f0f2786c2334#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759).